### PR TITLE
change default limit from 10 to 100

### DIFF
--- a/apps/poc-next/app/discover/page.tsx
+++ b/apps/poc-next/app/discover/page.tsx
@@ -39,7 +39,7 @@ const Discover = () => {
   const [mixCompleted, setMixCompleted] = useState<boolean>(false)
   const [userLikes, setUserLikes] = useState<string[]>([])
   const [currentPage, setCurrentPage] = useState<number>(1)
-  const currentLimit = 10
+  const currentLimit = 100
   const [shouldFetch, setShouldFetch] = useState<boolean>(true)
 
   const { data, error, isLoading } = useSWR(

--- a/apps/poc-next/app/discover/utils.ts
+++ b/apps/poc-next/app/discover/utils.ts
@@ -9,11 +9,11 @@ import { getRawTransactionToSign } from "@/lib/utils"
 export const getMix: Fetcher<
   { urls: C4Content[] },
   { tags: TagMap; page: number; limit?: number }
-> = ({ tags, limit = "10", page }) => {
+> = ({ tags, limit = "100", page }) => {
   const tagQueries = new URLSearchParams()
   tags.forEach((tag) => tagQueries.append("tags", tag._id))
   tagQueries.append("page", page.toString() || "1")
-  tagQueries.append("limit", limit.toString() || "10")
+  tagQueries.append("limit", limit.toString() || "100")
   return fetch(
     `${process.env.NEXT_PUBLIC_API_URL}/mix?${tagQueries.toString()}`
   ).then((response) => response.json())

--- a/backend/controllers/contractController.js
+++ b/backend/controllers/contractController.js
@@ -32,7 +32,7 @@ const create_user = async(req, res) => {
 const get_all_users = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1; // Get the page number from query parameters, default to 1 if not provided
-    const limit = parseInt(req.query.limit) || 10; // Get the limit from query parameters, default to 10 if not provided
+    const limit = parseInt(req.query.limit) || 100; // Get the limit from query parameters, default to 100 if not provided
 
     const [users, count] = await Promise.all([
       User.find()
@@ -273,7 +273,7 @@ const getUrlsByTags = async (req, res) => {
   try {
     const tags = req.query.tags || ''; // Get the tags from query parameters
     const page = parseInt(req.query.page) || 1; // Get the page number from query parameters, default to 1 if not provided
-    const limit = parseInt(req.query.limit) || 10; // Get the limit from query parameters, default to 10 if not provided
+    const limit = parseInt(req.query.limit) || 100; // Get the limit from query parameters, default to 100 if not provided
 
     const [urls, count] = await Promise.all([
       Url.find({ tags: { $in: tags } })
@@ -309,7 +309,7 @@ const shuffleArray = (array) => {
 // mix feed
 const mix = async (req, res) => {
   try {
-    const { tags, page = 1, limit = 10 } = req.query;
+    const { tags, page = 1, limit = 100 } = req.query;
     console.log("tags : page : limit ", tags, page, limit)
     // Fetch the URLs based on the provided tags
     const [urls, count] = await Promise.all([


### PR DESCRIPTION
From tpan feedback suggesting changing limit from 10 to 100. 100 is reasonable number of urls we can send at a time and will not slow down frontend. 

